### PR TITLE
moved pytest-runner from tests_require to tests_require at setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     license='GPLv3',
     package_dir={"": "src"},
     packages=["redicts"],
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    setup_requires=[],
+    tests_require=['pytest', 'pytest-runner'],
     long_description=read("README.rst"),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest==3.3.1
+pytest-runner==4.0
 pytest_cov==2.5.1
 python_coveralls==2.9.1


### PR DESCRIPTION
dependency was missing (pytest-runner) when installing redicts:
```
Collecting redicts==1.0.4
  Downloading http://pypi.python.org/packages/redicts/download/27276/redicts-1.0.4.tar.gz
    Complete output from command python setup.py egg_info:
    Couldn't find index page for 'pytest-runner' (maybe misspelled?)
    No local packages or download links found for pytest-runner
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-zMrfoC/redicts/setup.py", line 25, in <module>
        "Topic :: Software Development :: Libraries :: Python Modules",
      File "/usr/lib/python2.7/distutils/core.py", line 112, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 221, in __init__
        self.fetch_build_eggs(attrs.pop('setup_requires'))
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 245, in fetch_build_eggs
        parse_requirements(requires), installer=self.fetch_build_egg
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 576, in resolve
        dist = best[req.key] = env.best_match(req, self, installer)
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 821, in best_match
        return self.obtain(req, installer) # try and download/install
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 833, in obtain
        return installer(requirement)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 294, in fetch_build_egg
        return cmd.easy_install(req)
      File "/usr/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 602, in easy_install
        raise DistutilsError(msg)
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('pytest-runner')

```
This happened due to  having `pytest-runner` dependency in `setup_requires` instead of `tests_require`

